### PR TITLE
add entry for Manuel Herrmann (_0x17de)

### DIFF
--- a/README.org
+++ b/README.org
@@ -45,6 +45,7 @@
 | Lars Andersen         | [[https://github.com/expez/.emacs.d][.emacs.d]]             |                          |          |                      |               | ✔        |                                                                         |
 | Lars Tveito           | [[https://github.com/larstvei/dot-emacs][dot-emacs]]            |                          | ✔        |                      |               | ✔        |                                                                         |
 | Magnar Sveen          | [[https://github.com/magnars/.emacs.d][.emacs.d]]             |                          | ✔        |                      |               | ✔        |                                                                         |
+| [[https://www.manuel-herrmann.de][Manuel Herrmann]]       | [[https://github.com/0x17de/emacs-config][emacs-config]]         | classic                  |          | use-package          |           24+ | ✔        | autocompletions for C++, python, golang, rust, LaTeX                    |
 | Mark Karpov           | [[https://github.com/mrkkrp/dot-emacs][dot-emacs]]            |                          |          |                      |           25+ | ✔        |                                                                         |
 | Name                  | config               | Key Bindings             | Literate | Package              | Emacs version | Clonable | Highlights                                                              |
 


### PR DESCRIPTION
This configuration should be easy to install and contains a lot of packages for autocompletions of some specifig programming languages - I and my colleague use it productivly mostly for C++/python, so i have someone who can directly complain if something is broken :). A better description might be inside README.md of that repository at https://github.com/0x17de/emacs-config

The hotkeys are basically the classic ones but some overrides happen, like:
- no confirm on kill-buffer
- tab is autocompletion
- S-tab is a tab character
- C-M-z is the prefix for my userdefined commands, but sometimes <f1> or <f5> is defined for documentation lookup or compilation