### PR TITLE
Add MinEmacs

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,6 +10,7 @@
    - [[https://github.com/thefrontside/frontmacs][Frontmacs]]
    - [[https://github.com/rdallasgray/graphene][Graphene]]
    - [[https://github.com/bodil/ohai-emacs][Ohai Emacs]]
+   - [[https://github.com/abougouffa/minemacs][MinEmacs]]
 
 ** A list of people with nice [[https://www.gnu.org/software/emacs/][emacs]] config files
 


### PR DESCRIPTION
[[https://github.com/abougouffa/minemacs][MinEmacs]] is a minimal Emacs configuration framework, with Evil keybindings, inspired by Doom (and Spacemacs), but much lighter!