### PR TITLE
Add JCS-Emacs

### DIFF
--- a/README.org
+++ b/README.org
@@ -11,6 +11,7 @@
    - [[https://github.com/thefrontside/frontmacs][Frontmacs]]
    - [[https://github.com/rougier/nano-emacs][Nano Emacs]]
    - [[https://github.com/abougouffa/minemacs][MinEmacs]]
+   - [[https://github.com/jcs-emacs/jcs-emacs][JCS-Emacs]]
 
 ** A list of people with nice [[https://www.gnu.org/software/emacs/][emacs]] config files
 


### PR DESCRIPTION
[JCS-Emacs](https://github.com/jcs-emacs/jcs-emacs) is a cross-platform, general-purpose configuration with unique key bindings. It features a custom built-in module system inspired by Doom Emacs. Additionally, it includes a dedicated package repository, [JCS-ELPA](https://github.com/jcs-emacs/jcs-elpa), designed specifically for it.