### PR TITLE
Add Corgi Emacs

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,6 +13,7 @@
    - [[https://github.com/abougouffa/minemacs][MinEmacs]]
    - [[https://github.com/jcs-emacs/jcs-emacs][JCS-Emacs]]
    - [[https://github.com/jamescherti/minimal-emacs.d][minimal-emacs.d]]
+   - [[https://github.com/corgi-emacs/corgi][Corgi Emacs]]
 
 
 ** A list of people with nice [[https://www.gnu.org/software/emacs/][emacs]] config files


### PR DESCRIPTION
Corgi is a more lightweight alternative to Spacemacs and Doom with a lightweight configurable keybinding system, aimed at Clojure developers who use a vim-style modal editing workflow.